### PR TITLE
fix crs issue with feature_representation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: prioritizr
 Type: Package
-Version: 5.0.1.5
+Version: 5.0.1.6
 Title: Systematic Conservation Prioritization in R
 Description: Conservation prioritization using integer
     programming techniques. To solve large-scale problems, users
@@ -78,7 +78,7 @@ URL: https://prioritizr.net,
     https://github.com/prioritizr/prioritizr
 BugReports: https://github.com/prioritizr/prioritizr/issues
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Collate:
     'internal.R'
     'pproto.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# prioritizr 5.0.1.6
+
+- Fix `feature_representation` bug incorrectly throwing error with vector 
+  planning unit data (e.g. sf-class data).
+
 # prioritizr 5.0.1.5
 
 - Fix typo causing `rij_matrix` to throw an error for large raster data (#151).

--- a/R/feature_representation.R
+++ b/R/feature_representation.R
@@ -317,15 +317,15 @@ methods::setMethod("feature_representation",
     assertthat::assert_that(
       inherits(solution, "sf"),
       inherits(x$data$cost, "sf"))
-    solution <- sf::st_drop_geometry(solution)
     assertthat::assert_that(
       sf::st_crs(x$data$cost) == sf::st_crs(solution),
-      number_of_zones(x) == ncol(solution),
+      number_of_zones(x) == ncol(sf::st_drop_geometry(solution)),
       number_of_total_units(x) == nrow(solution),
-      is.numeric(unlist(solution)),
-      min(unlist(solution), na.rm = TRUE) >= 0,
-      max(unlist(solution), na.rm = TRUE) <= 1)
+      is.numeric(unlist(sf::st_drop_geometry(solution))),
+      min(unlist(sf::st_drop_geometry(solution)), na.rm = TRUE) >= 0,
+      max(unlist(sf::st_drop_geometry(solution)), na.rm = TRUE) <= 1)
     # perform calculations
+    solution <- sf::st_drop_geometry(solution)
     internal_feature_representation(x, as.matrix(solution))
 })
 

--- a/tests/testthat/test_feature_representation.R
+++ b/tests/testthat/test_feature_representation.R
@@ -147,6 +147,7 @@ test_that("Spatial (single zone)", {
   # load data
   data(sim_pu_polygons)
   pu <- sim_pu_polygons
+  pu@proj4string <- sp::CRS("+init=epsg:32756")
   pu$cost[1:5] <- NA
   pu$solution <- rep(c(0, 1), 5)
   pu$solution[is.na(pu$cost)] <- NA_real_
@@ -176,6 +177,7 @@ test_that("Spatial (multiple zone)", {
   # load data
   data(sim_pu_zones_polygons)
   pu <- sim_pu_zones_polygons
+  pu@proj4string <- sp::CRS("+init=epsg:32756")
   pu$spp1_1 <- c(NA, runif(nrow(pu) - 1))
   pu$spp2_1 <- c(rpois(nrow(pu) - 1, 1),
                                     NA)
@@ -216,6 +218,7 @@ test_that("sf (single zone)", {
   # load data
   data(sim_pu_sf)
   pu <- sim_pu_sf
+  sf::st_crs(pu) <- sf::st_crs(32756)
   pu$cost[1:5] <- NA
   pu$solution <- rep(c(0, 1), 5)
   pu$solution[is.na(pu$cost)] <- NA_real_
@@ -245,6 +248,7 @@ test_that("sf (multiple zone)", {
   # load data
   data(sim_pu_zones_sf)
   pu <- sim_pu_zones_sf
+  sf::st_crs(pu) <- sf::st_crs(32756)
   pu$spp1_1 <- c(NA, runif(nrow(pu) - 1))
   pu$spp2_1 <- c(rpois(nrow(pu) - 1, 1),
                                     NA)
@@ -284,6 +288,8 @@ test_that("sf (multiple zone)", {
 test_that("Raster (single zone)", {
   # load data
   data(sim_pu_raster, sim_features)
+  sim_pu_raster@crs <- sp::CRS("+init=epsg:32756")
+  sim_features@crs <- sp::CRS("+init=epsg:32756")
   # create problem
   x <- problem(sim_pu_raster, sim_features)
   # create a solution
@@ -309,6 +315,10 @@ test_that("Raster (single zone)", {
 test_that("Raster (multiple zone)", {
   # load data
   data(sim_pu_zones_stack, sim_features_zones)
+  sim_pu_zones_stack@crs <- sp::CRS("+init=epsg:32756")
+  sim_features_zones[[1]]@crs <- sp::CRS("+init=epsg:32756")
+  sim_features_zones[[2]]@crs <- sp::CRS("+init=epsg:32756")
+  sim_features_zones[[3]]@crs <- sp::CRS("+init=epsg:32756")
   # create problem
   x <- problem(sim_pu_zones_stack, sim_features_zones)
   # create a solution
@@ -322,6 +332,7 @@ test_that("Raster (multiple zone)", {
   y[[1]][is.na(sim_pu_zones_stack[[1]])] <- NA_real_
   y[[2]][is.na(sim_pu_zones_stack[[2]])] <- NA_real_
   y[[3]][is.na(sim_pu_zones_stack[[3]])] <- NA_real_
+  raster::crs(y) <- sp::CRS("+init=epsg:32756")
   # calculate representation
   r <- feature_representation(x, y)
   # create correct result


### PR DESCRIPTION
The `feature_representation` function has a bug where it will throw an error claiming that the coordinate reference systems of the planning unit and solution data are not comparable for vector (e.g. `sf`) data. This PR fixes this issue. @ricschuster, could you please take a quick look and verify if it looks good to merge?